### PR TITLE
Fix getFunc return an empty PF-111

### DIFF
--- a/mods/funcs/src/client/funcs.ts
+++ b/mods/funcs/src/client/funcs.ts
@@ -148,7 +148,7 @@ export default class Funcs extends FonosService {
       super
         .getService()
         .getFunc(req, super.getMeta(), (e, res: FuncsPB.Func) => {
-          if (e) reject(e);
+          if (e) return reject(e);
 
           resolve({
             name: res.getName(),


### PR DESCRIPTION
The GetFunc backend should return an empty object if no object was found instead of an exception