### PR TITLE
Workaround to support default interop scenario with ES6/common.js

### DIFF
--- a/mods/agents/src/client/agents.ts
+++ b/mods/agents/src/client/agents.ts
@@ -248,3 +248,6 @@ export default class Agents extends FonosService {
 }
 
 export {AgentsPB, CommonPB};
+// WARNING:
+// Workaround to support default interop scenario with ES6/common.js 
+module.exports = Agents;

--- a/mods/auth/src/client/auth.ts
+++ b/mods/auth/src/client/auth.ts
@@ -43,7 +43,7 @@ import {
  * .then(console.log)       // returns an object with the token
  * .catch(console.error);   // an error occurred
  */
-export default class Agents extends FonosService {
+export default class Auths extends FonosService {
   /**
    * Constructs a new Auth object.
    * @param {ServiceOptions} options - Options to indicate the objects endpoint
@@ -146,3 +146,6 @@ export default class Agents extends FonosService {
 }
 
 export {AuthPB};
+// WARNING:
+// Workaround to support default interop scenario with ES6/common.js 
+module.exports = Auths;

--- a/mods/callmanager/src/client/callmanager.ts
+++ b/mods/callmanager/src/client/callmanager.ts
@@ -93,3 +93,6 @@ export default class CallManager extends FonosService {
 }
 
 export {CallManagerPB};
+// WARNING:
+// Workaround to support default interop scenario with ES6/common.js 
+module.exports = CallManager;

--- a/mods/domains/src/client/domains.ts
+++ b/mods/domains/src/client/domains.ts
@@ -285,3 +285,6 @@ export default class Domains extends FonosService {
 }
 
 export {DomainsPB, CommonPB};
+// WARNING:
+// Workaround to support default interop scenario with ES6/common.js 
+module.exports = Domains;

--- a/mods/funcs/src/client/funcs.ts
+++ b/mods/funcs/src/client/funcs.ts
@@ -286,3 +286,7 @@ export default class Funcs extends FonosService {
 }
 
 export {FuncsPB, CommonPB, buildDeployFuncRequest};
+// WARNING:
+// Workaround to support default interop scenario with ES6/common.js 
+module.exports = Funcs;
+

--- a/mods/googleasr/src/asr.ts
+++ b/mods/googleasr/src/asr.ts
@@ -37,4 +37,7 @@ class GoogleASR extends Plugin implements SpeechProvider {
 }
 
 export default GoogleASR;
+// WARNING:
+// Workaround to support default interop scenario with ES6/common.js 
+module.exports = GoogleASR;
 export {GoogleSpeechTracker, GoogleSpeechConfig};

--- a/mods/googletts/src/tts.ts
+++ b/mods/googletts/src/tts.ts
@@ -91,3 +91,7 @@ class GoogleTTS extends Plugin implements TTSPlugin {
 }
 
 export default GoogleTTS;
+// WARNING:
+// Workaround to support default interop scenario with ES6/common.js 
+module.exports = GoogleTTS;
+

--- a/mods/marytts/src/mary_tts.ts
+++ b/mods/marytts/src/mary_tts.ts
@@ -129,3 +129,7 @@ export default class MaryTTS extends Plugin implements TTSPlugin {
     });
   }
 }
+
+// WARNING:
+// Workaround to support default interop scenario with ES6/common.js 
+module.exports = MaryTTS;

--- a/mods/numbers/src/client/numbers.ts
+++ b/mods/numbers/src/client/numbers.ts
@@ -315,3 +315,7 @@ export default class Numbers extends FonosService {
 }
 
 export {NumbersPB, CommonPB};
+// WARNING:
+// Workaround to support default interop scenario with ES6/common.js 
+module.exports = Numbers;
+

--- a/mods/providers/src/client/providers.ts
+++ b/mods/providers/src/client/providers.ts
@@ -271,3 +271,7 @@ export default class Providers extends FonosService {
 }
 
 export {ProvidersPB, CommonPB};
+// WARNING:
+// Workaround to support default interop scenario with ES6/common.js 
+module.exports = Providers;
+

--- a/mods/sdk/src/index.ts
+++ b/mods/sdk/src/index.ts
@@ -42,3 +42,6 @@ const Fonos = {
 };
 
 export {Fonos as default};
+// WARNING:
+// Workaround to support default interop scenario with ES6/common.js 
+module.exports = Fonos;

--- a/mods/secrets/src/client/secrets.ts
+++ b/mods/secrets/src/client/secrets.ts
@@ -198,3 +198,6 @@ export default class Secrets extends FonosService {
 }
 
 export {SecretPB, CommonPB};
+// WARNING:
+// Workaround to support default interop scenario with ES6/common.js 
+module.exports = Secrets;

--- a/mods/storage/src/client/storage.ts
+++ b/mods/storage/src/client/storage.ts
@@ -128,3 +128,7 @@ export default class Storage extends FonosService {
 }
 
 export {StoragePB, CommonPB};
+// WARNING:
+// Workaround to support default interop scenario with ES6/common.js 
+module.exports = Storage;
+


### PR DESCRIPTION
1 - Workaround was added to all clients.
2 - Class name changed to corresponding from Agents to Auths.