### PR TITLE
reversing last changes over protos generation

### DIFF
--- a/etc/gen_code_proto.sh
+++ b/etc/gen_code_proto.sh
@@ -25,3 +25,5 @@ done
 # Cleaning callmanager and auth stubs
 rm $DIRNAME/../mods/callmanager/src/service/protos/common_*
 rm $DIRNAME/../mods/auth/src/service/protos/common_*
+
+#Last changes reversed


### PR DESCRIPTION
It seems that the abstraction layer of the GRCP methods looks different after last changes applied. 
First refactoring still open to research.