### PR TITLE
feat: add * to active project cli projects:ls

### DIFF
--- a/mods/ctl/src/commands/projects/list.ts
+++ b/mods/ctl/src/commands/projects/list.ts
@@ -34,6 +34,10 @@ export default class ListCommand extends Command {
       const projects = new Projects();
       // Gets the list
       const result = await projects.listProjects({});
+      // 1st project is the default project
+      if (result.projects?.length !== 0) {
+        result.projects[0].name = `${result.projects[0].name} *`;
+      }
       CliUx.ux.table(result.projects, {
         accessKeyId: { header: "Ref / Access Key Id", minWidth: 30 },
         name: { header: "Name", minWidth: 12 }

--- a/mods/ctl/src/commands/projects/list.ts
+++ b/mods/ctl/src/commands/projects/list.ts
@@ -16,10 +16,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import "../../config";
 import { CLIError } from "@oclif/errors";
 import { Command } from "@oclif/command";
 import { CliUx } from "@oclif/core";
+import { isDefaultProject } from "../../config";
 const Projects = require("@fonoster/projects");
 
 export default class ListCommand extends Command {
@@ -34,11 +34,8 @@ export default class ListCommand extends Command {
       const projects = new Projects();
       // Gets the list
       const result = await projects.listProjects({});
-      // 1st project is the default project
-      if (result.projects?.length !== 0) {
-        result.projects[0].name = `${result.projects[0].name} *`;
-      }
-      CliUx.ux.table(result.projects, {
+      const proj = result.projects?.map(p => Object.assign(p, {name: isDefaultProject(p.ref) ? `${p.name} *` : p.name}));
+      CliUx.ux.table(proj, {
         accessKeyId: { header: "Ref / Access Key Id", minWidth: 30 },
         name: { header: "Name", minWidth: 12 }
       });

--- a/mods/ctl/src/commands/projects/list.ts
+++ b/mods/ctl/src/commands/projects/list.ts
@@ -34,8 +34,8 @@ export default class ListCommand extends Command {
       const projects = new Projects();
       // Gets the list
       const result = await projects.listProjects({});
-      const proj = result.projects?.map(p => Object.assign(p, {name: isDefaultProject(p.ref) ? `${p.name} *` : p.name}));
-      CliUx.ux.table(proj, {
+      const projs = result.projects?.map(p => Object.assign(p, {name: isDefaultProject(p.ref) ? `${p.name} *` : p.name}));
+      CliUx.ux.table(projs, {
         accessKeyId: { header: "Ref / Access Key Id", minWidth: 30 },
         name: { header: "Name", minWidth: 12 }
       });


### PR DESCRIPTION
#445 Hi @YuriCodes 

Please help me to review and give comment. I checked the payload for projects endpoint:

{
"ref":"PJ63732ecf28f2330007d97bbd",
"name":"TestProject",
"userRef":"US63732bcfa978a700071b7641",
"accessKeyId":"PJ63732ecf28f2330007d97bbd",
"accessKeySecret":"asdasd",
"allowExperiments":true,
"createTime":"2022-11-15T06:16:47.640Z",
"updateTime":"2022-11-19T23:57:36.841Z"
}

There is no attribute to tell me which one is default. so I assume the first project is the default.

I'm trying to use [https://oclif.io/docs/testing](@oclif/test) to test command but it's conflicting with our chai expect. If you can give me some hint to add unit test for this then it's great.

Thanks a lot.