### PR TITLE
feat: updated routr image to 1.2.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,7 +112,7 @@ jobs:
     - name: Copy and Push Routr image
       uses: akhilerm/tag-push-action@v2.0.0
       with:
-        src: docker.io/fonoster/routr:1.2.0
+        src: docker.io/fonoster/routr:1.2.4
         dst: |
           docker.io/fonoster/routr:${{ steps.get_version.outputs.VERSION }}
     - name: Copy and Push Rox as Voice image


### PR DESCRIPTION
Updating image to 1.2.4 will provide us with the following improvements:

1. Fixed not matching CSeq in response using IP based authentication
2. Enforcing E.164 numbers
