### PR TITLE
feat: flag to enforce e164

### DIFF
--- a/operator/compose/02_sipnet.yml
+++ b/operator/compose/02_sipnet.yml
@@ -18,7 +18,7 @@ services:
       EX_RTP_ENGINE_HOST: ${RTPE_HOST}
       EX_RTP_ENGINE_PORT: ${RTPE_PORT}
       # Setting this to true is breaking the routing workflow in Routr
-      EX_CONVERT_TEL_TO_E164: "false"
+      EX_CONVERT_TEL_TO_E164: "true"
       JAVA_OPTS: -XX:NewRatio=2 -Xmx250M
     ports:
       - ${SIPPROXY_SIP_PORTS}:${SIPPROXY_SIP_PORTS}


### PR DESCRIPTION
This PR changes the env `EX_CONVERT_TEL_TO_E164` to true for SIPNet operator. This will cause all numbers within enforce the E164 format for all calls including SDK.