### PR TITLE
fix: the docker operator shows empty logs when running without verbose mode

### DIFF
--- a/docker/bin/execute.sh
+++ b/docker/bin/execute.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-COMMAND_LOGS="exec.log"
+COMMAND_LOGS="/var/log/fonoster.log"
 
 function exec_command() {
   local COMMAND="$1"
@@ -24,10 +24,19 @@ function execute() {
       if [ -f $COMMAND_LOGS ]; then
         line
 
-        warning "Command output: 👀 "
-        warning " -------------------------------------------------- "
-        warning "$(cat $COMMAND_LOGS)"
-        warning " -------------------------------------------------- "
+        if [ -z "$VERBOSE" ]; then
+          warning "Last 10 lines of execution logs: 👀 "
+
+          line
+
+          echo " -------------------------------------------------- "
+          echo -e "\n $(tail -10 $COMMAND_LOGS) \n"
+          echo " -------------------------------------------------- "
+
+          line
+
+          info "To see the full logs, open the file: $COMMAND_LOGS"
+        fi
 
         line
       fi


### PR DESCRIPTION
## Description

The Docker Operator uses the verbose mode to display all the logs on the terminal or, failing that, if it is disabled, we use a file to add the logs of the Fonoster executions. This mechanism, for some reason, was not consistent and most of the time shows an empty log file.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- 
  Please describe the tests that you ran to verify your changes. 
  Provide instructions so we can reproduce. 
  Please also list any relevant details for your test configuration 
-->

- [x] Run the installation of Fonoster with the docker operator.
```sh
docker run -it --rm \
  -e CONFIG_PATH=$(pwd)/fonoster/config \
  --volume /var/run/docker.sock:/var/run/docker.sock \
  --volume $(pwd)/fonoster:/out:rw \
  fonoster/fonoster
```
- [x] After execution, if you get any errors, you can now go to the system log files and identify the `fonoster.log` file on your machine.
- [x] Run `cat /var/log/fonoster.log` or `tail -10 /var/log/fonoster.log` to see the last 10 lines of logs.

## Checklist:

<!-- Please delete options that are not relevant. -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings