### PR TITLE
Snack Bar UI Component

### DIFF
--- a/mods/webui/src/stories/link/modaltrigger/ModalTrigger.stories.ts
+++ b/mods/webui/src/stories/link/modaltrigger/ModalTrigger.stories.ts
@@ -17,14 +17,14 @@
  * limitations under the License.
  */
 
-/**
- * This story is for the modal trigger component based on Material UI.
- * It has a enabled and disabled variants.
- */
 import type { Meta, StoryObj } from "@storybook/react";
 import { ModalTrigger } from "./ModalTrigger";
 import { fn } from "@storybook/test";
 
+/**
+ * This story is for the modal trigger component based on Material UI.
+ * It has a enabled and disabled variants.
+ */
 const meta = {
   title: "Shared Components/ModalTrigger",
   component: ModalTrigger,

--- a/mods/webui/src/stories/snackbar/SnackBar.stories.ts
+++ b/mods/webui/src/stories/snackbar/SnackBar.stories.ts
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 2024 by Fonoster Inc (https://fonoster.com)
+ * http://github.com/fonoster/fonoster
+ *
+ * This file is part of Fonoster
+ *
+ * Licensed under the MIT License (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    https://opensource.org/licenses/MIT
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react";
+import { Snackbar } from "./SnackBar";
+import { action } from "@storybook/addon-actions";
+
+/**
+ * This story is for the Snackbar component based on Material UI.
+ * It demonstrates different positions and behavior of the snackbar.
+ */
+const meta = {
+  title: "Shared Components/Snackbar",
+  component: Snackbar,
+  parameters: {
+    layout: "centered",
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/OsZlne0RvIgoFlFKF7hnAU/Shared-Component-Library?node-id=276-34326&t=PCa7qoqJ5LyNWGvX-0"
+    }
+  },
+  tags: ["autodocs"],
+  args: {
+    message:
+      "Your API Key was successfully generated and has been copied to your keyboard.",
+    open: true,
+    position: "top-center",
+    onClose: action("Snackbar closed"),
+    autoHideDuration: 5000
+  },
+  argTypes: {
+    message: {
+      name: "Message",
+      description: "The message to display in the snackbar",
+      control: "text"
+    },
+    open: {
+      name: "Open",
+      description: "Controls the visibility of the snackbar",
+      control: "boolean"
+    },
+    onClose: {
+      name: "On Close",
+      description: "Function to call when snackbar is closed"
+    },
+    position: {
+      name: "Position",
+      description: "The position of the snackbar",
+      control: {
+        type: "select",
+        options: [
+          "top-center",
+          "top-right",
+          "top-left",
+          "bottom-center",
+          "bottom-right",
+          "bottom-left"
+        ]
+      }
+    },
+    autoHideDuration: {
+      name: "Auto-hide Duration",
+      description: "Time (in ms) before the snackbar hides automatically",
+      control: { type: "number" }
+    }
+  }
+} satisfies Meta<typeof Snackbar>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Default snackbar positioned at the top center
+ */
+export const TopCenter: Story = {
+  args: {
+    position: "top-center"
+  }
+};
+
+/**
+ * Snackbar positioned at the top-right corner
+ */
+export const TopRight: Story = {
+  args: {
+    position: "top-right"
+  }
+};
+
+/**
+ * Snackbar positioned at the top-left corner
+ */
+export const TopLeft: Story = {
+  args: {
+    position: "top-left"
+  }
+};
+
+/**
+ * Snackbar positioned at the bottom-center corner
+ */
+export const BottomCenter: Story = {
+  args: {
+    position: "bottom-center"
+  }
+};
+
+/**
+ * Snackbar positioned at the bottom-right corner
+ */
+export const BottomRight: Story = {
+  args: {
+    position: "bottom-right"
+  }
+};
+
+/**
+ * Snackbar positioned at the bottom-left corner
+ */
+export const BottomLeft: Story = {
+  args: {
+    position: "bottom-left"
+  }
+};

--- a/mods/webui/src/stories/snackbar/SnackBar.styles.ts
+++ b/mods/webui/src/stories/snackbar/SnackBar.styles.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2024 by Fonoster Inc (https://fonoster.com)
+ * http://github.com/fonoster/fonoster
+ *
+ * This file is part of Fonoster
+ *
+ * Licensed under the MIT License (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    https://opensource.org/licenses/MIT
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { styled } from "@mui/material/styles";
+
+export const StyledSnackbarContainer = styled("div")<{ position: string }>(({
+  position
+}) => {
+  const getPositionStyles = () => {
+    const positions = {
+      "top-center": {
+        justifyContent: "center",
+        alignItems: "flex-start",
+        paddingTop: "10px"
+      },
+      "top-right": {
+        justifyContent: "flex-end",
+        alignItems: "flex-start",
+        paddingRight: "10px"
+      },
+      "top-left": {
+        justifyContent: "flex-start",
+        alignItems: "flex-start",
+        paddingLeft: "10px"
+      },
+      "bottom-center": {
+        justifyContent: "center",
+        alignItems: "flex-end",
+        paddingCenter: "10px"
+      },
+      "bottom-right": {
+        justifyContent: "flex-end",
+        alignItems: "flex-end",
+        paddingRight: "10px"
+      },
+      "bottom-left": {
+        justifyContent: "flex-start",
+        alignItems: "flex-end",
+        paddingLeft: "10px"
+      }
+    };
+    return positions[position];
+  };
+
+  return {
+    display: "flex",
+    width: "100%",
+    height: "100%",
+    justifyContent: "center",
+    alignItems: "center",
+    ...getPositionStyles()
+  };
+});
+
+export const StyledSnackbar = styled("div")(({ theme }) => {
+  return {
+    width: "344px",
+    backgroundColor: "#CCEFE1",
+    color: "#053204",
+    borderRadius: "4px",
+    padding: "16px",
+    boxShadow: theme.shadows[4],
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: "10px"
+  };
+});
+
+export const StyledMessage = styled("div")(() => ({
+  width: "90%",
+  fontFamily: "Poppins",
+  fontSize: "12px",
+  fontWeight: 400,
+  textAlign: "left",
+  textUnderlinePosition: "from-font",
+  textDecorationSkipInk: "none",
+  letterSpacing: "0.01em",
+  lineHeight: "18px"
+}));
+
+export const StyledCloseButtonContainer = styled("div")(() => ({
+  width: "10%",
+  height: "auto",
+  cursor: "pointer",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center"
+}));

--- a/mods/webui/src/stories/snackbar/SnackBar.tsx
+++ b/mods/webui/src/stories/snackbar/SnackBar.tsx
@@ -1,0 +1,38 @@
+import React, { useEffect } from "react";
+import {
+  StyledSnackbarContainer,
+  StyledSnackbar,
+  StyledMessage,
+  StyledCloseButtonContainer
+} from "./SnackBar.styles";
+import Grow from "@mui/material/Grow";
+import { SnackBarProps } from "./types";
+import CloseIcon from "@mui/icons-material/Close";
+
+export const Snackbar: React.FC<SnackBarProps> = ({
+  message,
+  open,
+  onClose,
+  position,
+  autoHideDuration = 5000
+}) => {
+  useEffect(() => {
+    if (open && autoHideDuration) {
+      const timer = setTimeout(onClose, autoHideDuration);
+      return () => clearTimeout(timer);
+    }
+  }, [open, autoHideDuration, onClose]);
+
+  return (
+    <Grow in={open}>
+      <StyledSnackbarContainer position={position}>
+        <StyledSnackbar>
+          <StyledMessage>{message}</StyledMessage>
+          <StyledCloseButtonContainer onClick={onClose}>
+            <CloseIcon htmlColor="#053204" />
+          </StyledCloseButtonContainer>
+        </StyledSnackbar>
+      </StyledSnackbarContainer>
+    </Grow>
+  );
+};

--- a/mods/webui/src/stories/snackbar/types.ts
+++ b/mods/webui/src/stories/snackbar/types.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2024 by Fonoster Inc (https://fonoster.com)
+ * http://github.com/fonoster/fonoster
+ *
+ * This file is part of Fonoster
+ *
+ * Licensed under the MIT License (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    https://opensource.org/licenses/MIT
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+type SnackBarProps = {
+  message: string;
+  open: boolean;
+  onClose: () => void;
+  position:
+    | "top-center"
+    | "top-right"
+    | "top-left"
+    | "bottom-center"
+    | "bottom-right"
+    | "bottom-left";
+
+  autoHideDuration: number;
+};
+
+export type { SnackBarProps };


### PR DESCRIPTION
## Description

The Snackbar should follow the design in the Figma file and be implemented as a standalone React component with the following props: message, open, onClose, position, autoHideDuration.

[Create the Snackbar component for the Storybook](https://github.com/fonoster/fonoster/issues/678)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## UI Component:

I've added positions like top-center, top-right, top-left, bottom-center, bottom-right, and bottom-left. Still, the parent component's width and height in the Stories documentation aren't suitable for testing these positions. I adjusted the parent's styles locally and attached screenshots showcasing each position to address this.

### top-center
<img width="1511" alt="Screenshot 2024-12-22 at 1 17 42 PM" src="https://github.com/user-attachments/assets/5fdc8c93-10b6-4c7a-925e-f9b3f7b695c3" />

### top-right
<img width="1509" alt="Screenshot 2024-12-22 at 1 17 50 PM" src="https://github.com/user-attachments/assets/05481f56-b68c-48a1-ad23-0af5e59b9a06" />

### top-left
<img width="1512" alt="Screenshot 2024-12-22 at 1 17 57 PM" src="https://github.com/user-attachments/assets/614d4e93-209f-40a8-8751-eefd9385f2d5" />

### bottom-center
<img width="1512" alt="Screenshot 2024-12-22 at 1 18 06 PM" src="https://github.com/user-attachments/assets/244bf1f7-7cca-4adc-98aa-745486b9ccc0" />

### bottom-right
<img width="1512" alt="Screenshot 2024-12-22 at 1 18 13 PM" src="https://github.com/user-attachments/assets/0645e074-5c38-4858-96b1-deb1fa66fb26" />

### bottom-left
<img width="1512" style="text-align: center"  alt="Screenshot 2024-12-22 at 1 18 20 PM" src="https://github.com/user-attachments/assets/3faa6159-3de1-42db-acca-3bb4d28ab2cb" />