### PR TITLE
Update to only show the last digits of the uuid

### DIFF
--- a/mods/dashboard/src/core/components/design-system/ui/data-table/elements/data-table-body.tsx
+++ b/mods/dashboard/src/core/components/design-system/ui/data-table/elements/data-table-body.tsx
@@ -21,6 +21,7 @@ import { TableBody, TableCell, TableRow } from "@mui/material";
 
 import { useDataTable } from "../data-table.context";
 import { Checkbox } from "../../checkbox/checkbox";
+import { lastUuidSegment } from "../../../../../../core/helpers/last-uuid-segment";
 
 /**
  * Props definition for a single row in the DataTableBody.
@@ -47,7 +48,9 @@ const DataRow = ({ row, showSelection }: DataTableBodyRowProps) => (
 
     {row.getVisibleCells().map((cell: any) => (
       <TableCell key={cell.id}>
-        {flexRender(cell.column.columnDef.cell, cell.getContext())}
+        {cell.column.id === "ref"
+          ? lastUuidSegment(cell.getValue() as string)
+          : flexRender(cell.column.columnDef.cell, cell.getContext())}
       </TableCell>
     ))}
   </TableRow>

--- a/mods/dashboard/src/core/helpers/last-uuid-segment.ts
+++ b/mods/dashboard/src/core/helpers/last-uuid-segment.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2025 by Fonoster Inc (https://fonoster.com)
+ * http://github.com/fonoster/fonoster
+ *
+ * This file is part of Fonoster
+ *
+ * Licensed under the MIT License (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    https://opensource.org/licenses/MIT
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * lim
+
+/**
+ * Returns the last segment of a dash-separated UUID string.
+ * If no dash is found, returns the original string.
+ * 
+ * @param str - The string to extract the last segment from.
+ * @returns The last segment of the string, or the original string if no dash is found.
+ */
+export function lastUuidSegment(str: string): string {
+  return str ? str.split("-").pop() || str : "";
+}


### PR DESCRIPTION
## Description

Small change to only show a portion of the UUID. Later we will need to update all the "Edit" section to have the full uuid and make it easier to copy.

<img width="1192" alt="Screenshot 2025-06-29 at 9 38 41 PM" src="https://github.com/user-attachments/assets/dee285e3-0aa9-4ba3-a8a4-ce9bd06515b2" />

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested the change locally with multiple resource types.

## Checklist:

<!-- Please delete options that are not relevant. -->

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules