### PR TITLE
Fix pressing twice for test calls

### DIFF
--- a/mods/dashboard/src/applications/pages/create-application/create-application.container.tsx
+++ b/mods/dashboard/src/applications/pages/create-application/create-application.container.tsx
@@ -140,7 +140,10 @@ export function CreateApplicationContainer() {
   useEffect(() => {
     if (application?.ref && !isConnected) {
       connect(application.ref).catch((error) => {
-        Logger.debug("[CreateApplicationContainer] Failed to pre-connect test phone", error);
+        Logger.debug(
+          "[CreateApplicationContainer] Failed to pre-connect test phone",
+          error
+        );
       });
     }
   }, [application?.ref, isConnected, connect]);

--- a/mods/dashboard/src/applications/pages/create-application/create-application.container.tsx
+++ b/mods/dashboard/src/applications/pages/create-application/create-application.container.tsx
@@ -63,9 +63,8 @@ export function CreateApplicationContainer() {
   /** SIP calling logic and connection state from hook. */
   const {
     audioRef,
-    state: { isConnected, isRegistered, isCalling },
+    state: { isConnected, isCalling },
     connect,
-    register,
     call,
     close
   } = useTestCall();
@@ -101,7 +100,7 @@ export function CreateApplicationContainer() {
 
   /**
    * Triggers a test call using the SIP client once the app has been saved.
-   * Calls connect, register, and call in sequence.
+   * Calls connect and call in sequence.
    */
   const onTestCall = useCallback(async () => {
     if (!application.ref) {
@@ -117,15 +116,13 @@ export function CreateApplicationContainer() {
 
       if (!isConnected) await connect(appRef);
 
-      if (!isRegistered) await register();
-
       await call(appRef);
     } catch (err) {
       toast(getErrorMessage(err));
     } finally {
       setIsTestCallDisabled(false);
     }
-  }, [application, connect, register, call, isConnected, isRegistered]);
+  }, [application, connect, call, isConnected]);
 
   /**
    * Cleanup SIP session on component unmount.

--- a/mods/dashboard/src/applications/pages/create-application/create-application.container.tsx
+++ b/mods/dashboard/src/applications/pages/create-application/create-application.container.tsx
@@ -38,6 +38,7 @@ import {
   useApplicationContext
 } from "~/applications/stores/application.store";
 import type { Schema } from "./schemas/application-schema";
+import { Logger } from "~/core/shared/logger";
 
 export function CreateApplicationContainer() {
   /** Extract workspace ID for routing context. */
@@ -132,6 +133,17 @@ export function CreateApplicationContainer() {
       close(); // Hangs up any ongoing call
     };
   }, []);
+
+  /**
+   * Pre-connect the test phone when the application is created and available
+   */
+  useEffect(() => {
+    if (application?.ref && !isConnected) {
+      connect(application.ref).catch((error) => {
+        Logger.debug("[CreateApplicationContainer] Failed to pre-connect test phone", error);
+      });
+    }
+  }, [application?.ref, isConnected, connect]);
 
   return (
     <ApplicationProvider>


### PR DESCRIPTION
## Description

This fixes having to press the "test" button call twice to original a call.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Manually tested but it would be great to confirm the PR has no fluf and if other things can be cleanup.

## Checklist:

<!-- Please delete options that are not relevant. -->

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules