### PR TITLE
Session cleanup on tab close

### DIFF
--- a/mods/dashboard/src/applications/hooks/use-session-cleanup.ts
+++ b/mods/dashboard/src/applications/hooks/use-session-cleanup.ts
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) 2025 by Fonoster Inc (https://fonoster.com)
+ * http://github.com/fonoster/fonoster
+ *
+ * This file is part of Fonoster
+ *
+ * Licensed under the MIT License (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    https://opensource.org/licenses/MIT
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEffect } from "react";
+
+/**
+ * useSessionCleanup
+ *
+ * Custom React hook to call a cleanup function (e.g., close a session)
+ * when the user closes the tab or browser window.
+ *
+ * @param cleanupFn - The function to call on beforeunload (should be synchronous or use sendBeacon for async)
+ *
+ * @example
+ *   useSessionCleanup(close);
+ */
+export function useSessionCleanup(cleanupFn: () => void) {
+  useEffect(() => {
+    const handleBeforeUnload = () => {
+      cleanupFn();
+    };
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => {
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+    };
+  }, [cleanupFn]);
+} 

--- a/mods/dashboard/src/applications/hooks/use-session-cleanup.ts
+++ b/mods/dashboard/src/applications/hooks/use-session-cleanup.ts
@@ -39,4 +39,4 @@ export function useSessionCleanup(cleanupFn: () => void) {
       window.removeEventListener("beforeunload", handleBeforeUnload);
     };
   }, [cleanupFn]);
-} 
+}

--- a/mods/dashboard/src/applications/hooks/use-test-call.ts
+++ b/mods/dashboard/src/applications/hooks/use-test-call.ts
@@ -22,6 +22,7 @@ import { useSipTestCall } from "./use-sip";
 import { toast } from "~/core/components/design-system/ui/toaster/toaster";
 import { getErrorMessage } from "~/core/helpers/extract-error-message";
 import { useApplicationContext } from "../stores/application.store";
+import { useSessionCleanup } from "./use-session-cleanup";
 
 /**
  * useApplicationTestCall
@@ -54,6 +55,9 @@ export const useApplicationTestCall = () => {
     call,
     close
   } = useSipTestCall();
+
+  // Ensure SIP session is closed on tab/browser close
+  useSessionCleanup(close);
 
   /**
    * onTestCall


### PR DESCRIPTION
## Description

This PR ensures that the SIP session is properly closed when the user closes the tab or browser window, even if they do not explicitly hang up the call.

A new custom React hook, useSessionCleanup, was implemented and integrated into the useApplicationTestCall hook. This guarantees that the close function is called on the beforeunload event, preventing orphaned SIP sessions and potential resource leaks.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Manual testing.

## Checklist:

<!-- Please delete options that are not relevant. -->

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules