### PR TITLE
Update the monitor/call-logs table to use friendly labels

### DIFF
--- a/mods/dashboard/src/applications/services/applications.service.ts
+++ b/mods/dashboard/src/applications/services/applications.service.ts
@@ -79,7 +79,7 @@ export const useApplications = (params?: ResourceListRequest) => {
 /**
  * Hook to fetch a test token for an application.
  * This token is used to initiate a SIP test call.
- * 
+ *
  * It uses React Query to:
  * - Fetch the test token from the backend.
  * - Cache the result for 30 minutes to avoid frequent requests.

--- a/mods/dashboard/src/core/hooks/use-resource-table.ts
+++ b/mods/dashboard/src/core/hooks/use-resource-table.ts
@@ -20,6 +20,7 @@ import { useState, useCallback, useMemo } from "react";
 import { getNestedValue } from "../helpers/get-nested-value";
 import type { BaseApiObject } from "../providers/query-client/manage-resource-cache.helper";
 import { toast } from "../components/design-system/ui/toaster/toaster";
+import { STATUS_LABELS, DIRECTION_LABELS, TYPE_LABELS } from "../../monitoring/pages/calls/calls.const";
 
 /**
  * Interface representing the options passed to the useResourceTable hook.
@@ -131,7 +132,7 @@ export function useResourceTable<TResource extends { ref: string }>(
           `Are you sure you want to delete ${rows.length} resources?`
         )
       ) {
-        rows.map((r) => deleteResource(r.ref));
+        rows.forEach((r) => deleteResource(r.ref));
 
         toast("Resources deleted successfully!");
       }
@@ -148,11 +149,37 @@ export function useResourceTable<TResource extends { ref: string }>(
 
     if (!searchTerm) return data;
 
+    // Custom filtering for user-friendly fields
     return data.filter((resource) => {
       const rawValue = getNestedValue(resource, searchBy);
       const value = rawValue?.toString().toLowerCase();
+      const term = searchTerm.toLowerCase();
+      const rawKey = typeof rawValue === "string" ? rawValue : "";
 
-      return value?.includes(searchTerm.toLowerCase());
+      // For user-friendly fields, match both raw and label
+      if (searchBy === "status") {
+        const label = STATUS_LABELS[rawKey] || rawKey;
+        return (
+          value?.includes(term) ||
+          label?.toString().toLowerCase().includes(term)
+        );
+      }
+      if (searchBy === "direction") {
+        const label = DIRECTION_LABELS[rawKey] || rawKey;
+        return (
+          value?.includes(term) ||
+          label?.toString().toLowerCase().includes(term)
+        );
+      }
+      if (searchBy === "type") {
+        const label = TYPE_LABELS[rawKey] || rawKey;
+        return (
+          value?.includes(term) ||
+          label?.toString().toLowerCase().includes(term)
+        );
+      }
+      // Default: match raw value only
+      return value?.includes(term);
     });
   }, [data, searchTerm, searchBy]);
 

--- a/mods/dashboard/src/core/hooks/use-resource-table.ts
+++ b/mods/dashboard/src/core/hooks/use-resource-table.ts
@@ -20,7 +20,11 @@ import { useState, useCallback, useMemo } from "react";
 import { getNestedValue } from "../helpers/get-nested-value";
 import type { BaseApiObject } from "../providers/query-client/manage-resource-cache.helper";
 import { toast } from "../components/design-system/ui/toaster/toaster";
-import { STATUS_LABELS, DIRECTION_LABELS, TYPE_LABELS } from "../../monitoring/pages/calls/calls.const";
+import {
+  STATUS_LABELS,
+  DIRECTION_LABELS,
+  TYPE_LABELS
+} from "../../monitoring/pages/calls/calls.const";
 
 /**
  * Interface representing the options passed to the useResourceTable hook.

--- a/mods/dashboard/src/core/sdk/stores/fonoster.config.ts
+++ b/mods/dashboard/src/core/sdk/stores/fonoster.config.ts
@@ -37,4 +37,3 @@ export const FONOSTER_SERVER_CONFIG = Object.freeze({
 export const FONOSTER_RESET_PASSWORD_URL: string =
   import.meta.env.DASHBOARD_RESET_PASSWORD_URL ||
   "https://app.fonoster.com/auth/reset-password";
-

--- a/mods/dashboard/src/monitoring/pages/calls/calls.columns.tsx
+++ b/mods/dashboard/src/monitoring/pages/calls/calls.columns.tsx
@@ -18,6 +18,7 @@
  */
 import type { ColumnDef } from "@tanstack/react-table";
 import type { CallDetailRecord } from "@fonoster/types";
+import { STATUS_LABELS, DIRECTION_LABELS, TYPE_LABELS } from "./calls.const";
 
 /**
  * Column definitions for rendering a table of Fonoster Call Detail Records
@@ -26,6 +27,16 @@ import type { CallDetailRecord } from "@fonoster/types";
  * Each column maps a property of the `CallDetailRecord` object to a table header
  * and cell. This configuration enables sorting, filtering, and custom rendering in table UIs.
  */
+function formatDuration(duration: number): string {
+  if (duration < 60) {
+    return `${duration}s`;
+  } else if (duration < 3600) {
+    return `${Math.floor(duration / 60)}m`;
+  } else {
+    return `60m>`;
+  }
+}
+
 export const columns: ColumnDef<CallDetailRecord>[] = [
   {
     /**
@@ -46,7 +57,8 @@ export const columns: ColumnDef<CallDetailRecord>[] = [
      */
     id: "status",
     header: "Status",
-    accessorKey: "status"
+    accessorKey: "status",
+    cell: ({ getValue }) => STATUS_LABELS[getValue() as string] || getValue()
   },
   {
     /**
@@ -56,7 +68,8 @@ export const columns: ColumnDef<CallDetailRecord>[] = [
      */
     id: "direction",
     header: "Direction",
-    accessorKey: "direction"
+    accessorKey: "direction",
+    cell: ({ getValue }) => DIRECTION_LABELS[getValue() as string] || getValue()
   },
   {
     /**
@@ -86,7 +99,8 @@ export const columns: ColumnDef<CallDetailRecord>[] = [
      */
     id: "type",
     header: "Call Type",
-    accessorKey: "type"
+    accessorKey: "type",
+    cell: ({ getValue }) => TYPE_LABELS[getValue() as string] || getValue()
   },
   {
     /**
@@ -96,6 +110,7 @@ export const columns: ColumnDef<CallDetailRecord>[] = [
      */
     id: "duration",
     header: "Duration",
-    accessorKey: "duration"
+    accessorKey: "duration",
+    cell: ({ getValue }) => formatDuration(Number(getValue()))
   }
 ];

--- a/mods/dashboard/src/monitoring/pages/calls/calls.const.ts
+++ b/mods/dashboard/src/monitoring/pages/calls/calls.const.ts
@@ -75,3 +75,27 @@ export const CALLS_SEARCHABLE_FIELDS = [
    */
   { label: "Duration", value: "duration" }
 ];
+
+// User-friendly mappings for display
+export const STATUS_LABELS: Record<string, string> = Object.freeze({
+  UNKNOWN: "Unknown",
+  NORMAL_CLEARING: "Normal Clearing",
+  CALL_REJECTED: "Call Rejected",
+  UNALLOCATED: "Unallocated",
+  NO_USER_RESPONSE: "No Response",
+  NO_ROUTE_DESTINATION: "No Destination",
+  NO_ANSWER: "No Answer",
+  USER_BUSY: "User Busy",
+  NOT_ACCEPTABLE_HERE: "Not Acceptable",
+  SERVICE_UNAVAILABLE: "Service Unavailable",
+  INVALID_NUMBER_FORMAT: "Invalid Number Format"
+});
+export const DIRECTION_LABELS: Record<string, string> = Object.freeze({
+  INTRA_NETWORK: "Intra Network",
+  FROM_PSTN: "From PSTN",
+  TO_PSTN: "To PSTN"
+});
+export const TYPE_LABELS: Record<string, string> = Object.freeze({
+  SIP_ORIGINATED: "SIP Originated",
+  API_ORIGINATED: "API Originated"
+});


### PR DESCRIPTION
## Description

Update the monitor/call-logs table to use friendly labels and better formatting for the duration. It will now look like this:

<img width="1200" height="601" alt="Screenshot 2025-07-17 at 5 29 11 PM" src="https://github.com/user-attachments/assets/79cdfe63-9962-44ce-97e7-ad5a48f13838" />

## Type of change

<!-- 
  Choose all that apply and delete options that are not relevant.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Manually tested.

## Checklist:

<!-- Please delete options that are not relevant. -->

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules