### PR TITLE
Make dashboard configurable at runtime

### DIFF
--- a/mods/dashboard/src/auth/config/oauth.ts
+++ b/mods/dashboard/src/auth/config/oauth.ts
@@ -1,3 +1,5 @@
+import { BUILD_TIME_CONFIG } from "~/core/config/fonoster.buildtime-config";
+
 export interface OAuthConfig {
   clientId: string;
   redirectUri: string;
@@ -21,10 +23,10 @@ export interface OAuthState {
 }
 
 const createOAuthConfig = (scope: string): OAuthConfig => ({
-  clientId: import.meta.env.DASHBOARD_AUTH_GITHUB_CLIENT_ID!,
+  clientId: BUILD_TIME_CONFIG.GITHUB_OAUTH.clientId,
   redirectUri: "/",
-  redirectUriCallback: import.meta.env.DASHBOARD_AUTH_GITHUB_CALLBACK_URL,
-  authUrl: import.meta.env.DASHBOARD_AUTH_GITHUB_URL!,
+  redirectUriCallback: BUILD_TIME_CONFIG.GITHUB_OAUTH.callbackUrl,
+  authUrl: BUILD_TIME_CONFIG.GITHUB_OAUTH.authUrl,
   scope
 });
 

--- a/mods/dashboard/src/auth/pages/forgot-password/forgot-password.page.tsx
+++ b/mods/dashboard/src/auth/pages/forgot-password/forgot-password.page.tsx
@@ -29,7 +29,7 @@ import { Logger } from "~/core/shared/logger";
 import { useForgotPassword } from "~/auth/services/auth.service";
 import { toast } from "~/core/components/design-system/ui/toaster/toaster";
 import { useNavigate } from "react-router";
-import { FONOSTER_RESET_PASSWORD_URL } from "~/core/sdk/stores/fonoster.config";
+import { BUILD_TIME_CONFIG } from "~/core/config/fonoster.buildtime-config";
 
 export function meta(_: Route.MetaArgs) {
   return [{ title: "Forgot Password | Fonoster" }];
@@ -47,7 +47,7 @@ export default function ForgotPasswordPage() {
       );
       await mutateAsync({
         username,
-        resetPasswordUrl: FONOSTER_RESET_PASSWORD_URL
+        resetPasswordUrl: BUILD_TIME_CONFIG.RESET_PASSWORD_URL
       });
 
       toast(

--- a/mods/dashboard/src/core/components/general/sidebar/sidebar.tsx
+++ b/mods/dashboard/src/core/components/general/sidebar/sidebar.tsx
@@ -30,8 +30,9 @@ import {
   SidebarWrapper
 } from "./sidebar.styles";
 import { useSidebarItems } from "./sidebar-navigation.const";
+import { BUILD_TIME_CONFIG } from "~/core/config/fonoster.buildtime-config";
 
-const VERSION = import.meta.env.DASHBOARD_VERSION || "unset";
+const VERSION = BUILD_TIME_CONFIG.VERSION;
 
 export interface SidebarProps {
   workspaces: Workspace[];

--- a/mods/dashboard/src/core/config/fonoster.buildtime-config.ts
+++ b/mods/dashboard/src/core/config/fonoster.buildtime-config.ts
@@ -17,23 +17,24 @@
  * limitations under the License.
  */
 
-const { origin, hostname, port } = new URL(
-  import.meta.env.DASHBOARD_API_URL || "https://api.fonoster.com"
-);
+export interface BuildTimeConfig {
+  VERSION: string;
+  RESET_PASSWORD_URL: string;
+  GITHUB_OAUTH: {
+    clientId: string;
+    callbackUrl: string;
+    authUrl: string;
+  };
+}
 
-export const FONOSTER_CLIENT_CONFIG = Object.freeze({
-  url: origin,
-  accessKeyId: "",
-  allowInsecure: Boolean(import.meta.env.DASHBOARD_ALLOW_INSECURE === "true")
-});
-
-export const FONOSTER_SERVER_CONFIG = Object.freeze({
-  endpoint: `${hostname}${port ? `:${port}` : ""}`,
-  accessKeyId: "",
-  allowInsecure: Boolean(import.meta.env.DASHBOARD_ALLOW_INSECURE === "true"),
-  accessToken: ""
-});
-
-export const FONOSTER_RESET_PASSWORD_URL: string =
-  import.meta.env.DASHBOARD_RESET_PASSWORD_URL ||
-  "https://app.fonoster.com/auth/reset-password";
+export const BUILD_TIME_CONFIG: BuildTimeConfig = {
+  VERSION: import.meta.env.DASHBOARD_VERSION || "unset",
+  RESET_PASSWORD_URL:
+    import.meta.env.DASHBOARD_RESET_PASSWORD_URL ||
+    "https://app.fonoster.com/auth/reset-password",
+  GITHUB_OAUTH: {
+    clientId: import.meta.env.DASHBOARD_AUTH_GITHUB_CLIENT_ID || "",
+    callbackUrl: import.meta.env.DASHBOARD_AUTH_GITHUB_CALLBACK_URL || "",
+    authUrl: import.meta.env.DASHBOARD_AUTH_GITHUB_URL || ""
+  }
+};

--- a/mods/dashboard/src/core/config/fonoster.runtime-config.ts
+++ b/mods/dashboard/src/core/config/fonoster.runtime-config.ts
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) 2025 by Fonoster Inc (https://fonoster.com)
+ * http://github.com/fonoster/fonoster
+ *
+ * This file is part of Fonoster
+ *
+ * Licensed under the MIT License (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    https://opensource.org/licenses/MIT
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Fonoster Runtime Configuration
+ *
+ * @description This file provides runtime configuration management for the Fonoster Dashboard.
+ * It handles configuration loading from multiple sources with proper fallbacks for both
+ * server-side and client-side environments.
+ *
+ * @note Runtime configuration values can change during application execution and are
+ * loaded from environment variables or injected window objects.
+ */
+
+declare global {
+  interface Window {
+    __FONOSTER_RUNTIME_CONFIG__?: RuntimeConfig;
+  }
+}
+
+/**
+ * Runtime configuration interface defining all available configuration options.
+ *
+ * @description Defines the structure for runtime configuration values that can be
+ * dynamically loaded from environment variables or client-side injection.
+ */
+export interface RuntimeConfig {
+  /** Indicates whether the application is running in development mode */
+  DEVELOPMENT: boolean;
+  /** API server connection configuration */
+  APISERVER_CONNECTION: {
+    /** gRPC server address for API communication */
+    grpc_address: string;
+    /** HTTP server address for API communication */
+    http_address: string;
+    /** Whether to allow insecure connections (useful for development) */
+    allowInsecure: boolean;
+  };
+}
+
+/**
+ * Default runtime configuration values used as fallbacks.
+ *
+ * @description These values are used when no environment variables or
+ * client-side configuration is available. Points to production endpoints by default.
+ */
+const DEFAULT_RUNTIME_CONFIG: RuntimeConfig = {
+  DEVELOPMENT: false,
+  APISERVER_CONNECTION: {
+    grpc_address: "api.fonoster.com",
+    http_address: "https://api.fonoster.com",
+    allowInsecure: false
+  }
+};
+
+/**
+ * Reads an environment variable with a default value.
+ *
+ * @param key - The name of the environment variable to read
+ * @param defaultValue - The default value to return if the variable is not set
+ * @returns The value of the environment variable or the default value
+ */
+function readFromEnvWithDefault<T>(key: string, defaultValue: T): T {
+  const rawValue = process.env[key] || import.meta.env?.[key];
+
+  if (rawValue !== undefined) {
+    if (typeof defaultValue === "boolean") {
+      return (rawValue === "true") as T;
+    }
+    if (typeof defaultValue === "number") {
+      const num = Number(rawValue);
+      return (isNaN(num) ? defaultValue : num) as T;
+    }
+    return rawValue as unknown as T;
+  }
+
+  return defaultValue;
+}
+
+/**
+ * Reads runtime configuration from the appropriate source based on the environment.
+ *
+ * @description This function implements a multi-tier configuration loading strategy:
+ * 1. Server-side: Reads from process.env environment variables
+ * 2. Client-side: First tries window.__FONOSTER_RUNTIME_CONFIG__ (injected config)
+ * 3. Client-side fallback: Tries process.env if available
+ * 4. Final fallback: Uses DEFAULT_RUNTIME_CONFIG values
+ *
+ * @returns {RuntimeConfig} The resolved runtime configuration object
+ */
+function getRuntimeConfig(): RuntimeConfig {
+  const defaultConfig = DEFAULT_RUNTIME_CONFIG;
+  // Helper to read from process.env with fallbacks
+  const readFromEnv = (): RuntimeConfig => ({
+    DEVELOPMENT:
+      readFromEnvWithDefault<string>("NODE_ENV", "production") ===
+      "development",
+    APISERVER_CONNECTION: {
+      grpc_address: readFromEnvWithDefault<string>(
+        "DASHBOARD_APISERVER_GRPC_ADDRESS",
+        defaultConfig.APISERVER_CONNECTION.grpc_address
+      ),
+      http_address: readFromEnvWithDefault<string>(
+        "DASHBOARD_APISERVER_HTTP_ADDRESS",
+        defaultConfig.APISERVER_CONNECTION.http_address
+      ),
+      allowInsecure: readFromEnvWithDefault<boolean>(
+        "DASHBOARD_APISERVER_ALLOW_INSECURE",
+        defaultConfig.APISERVER_CONNECTION.allowInsecure
+      )
+    }
+  });
+
+  const isServer = typeof window === "undefined";
+
+  if (isServer) {
+    return readFromEnv();
+  }
+
+  return window.__FONOSTER_RUNTIME_CONFIG__ || readFromEnv();
+}
+
+/**
+ * The resolved runtime configuration object for the application.
+ *
+ * @description This is the main export that provides access to the current runtime
+ * configuration. It is resolved once during module initialization and contains
+ * the configuration values determined by the getRuntimeConfig() function.
+ *
+ * @example
+ * ```typescript
+ * import { RUNTIME_CONFIG } from './fonoster.runtime-config';
+ *
+ * // Access development mode flag
+ * const isDev = RUNTIME_CONFIG.DEVELOPMENT;
+ *
+ * // Access API server configuration
+ * const apiUrl = RUNTIME_CONFIG.APISERVER_CONNECTION.http_address;
+ * ```
+ */
+export const RUNTIME_CONFIG: RuntimeConfig = getRuntimeConfig();

--- a/mods/dashboard/src/core/sdk/client/fonoster.client.ts
+++ b/mods/dashboard/src/core/sdk/client/fonoster.client.ts
@@ -30,19 +30,33 @@
  */
 
 import * as SDK from "@fonoster/sdk/dist/web/index.esm.js";
-import { FONOSTER_CLIENT_CONFIG } from "../stores/fonoster.config";
+import { RUNTIME_CONFIG } from "../../config/fonoster.runtime-config";
 import { Logger } from "~/core/shared/logger";
 
 /**
- * Creates a new instance of the Fonoster WebClient using predefined configuration.
+ * Creates client configuration object using ApiServerConnectionConfig.
+ * Used for browser-based WebClient instances.
+ */
+const createClientConfig = () => {
+  return Object.freeze({
+    url: RUNTIME_CONFIG.APISERVER_CONNECTION.http_address,
+    accessKeyId: "",
+    allowInsecure: RUNTIME_CONFIG.APISERVER_CONNECTION.allowInsecure
+  });
+};
+
+/**
+ * Creates a new instance of the Fonoster WebClient using ApiServerConnectionConfig.
  *
  * @returns {Client} An instance of the Fonoster WebClient, ready for use in browser-based applications.
  */
-export const getClient = () => {
-  Logger.debug("[fonoster.client] Creating Fonoster WebClient instance");
-
-  const fonosterClient = new SDK.WebClient(FONOSTER_CLIENT_CONFIG);
-  return fonosterClient;
+export const getClient = (): SDK.Client => {
+  const clientConfig = createClientConfig();
+  Logger.debug(
+    "[fonoster.client] Creating Fonoster WebClient instance with client config",
+    clientConfig
+  );
+  return new SDK.WebClient(clientConfig);
 };
 
 /**

--- a/mods/dashboard/src/core/sdk/client/fonoster.server.ts
+++ b/mods/dashboard/src/core/sdk/client/fonoster.server.ts
@@ -32,13 +32,26 @@
  */
 
 import * as SDK from "@fonoster/sdk/dist/node/node.js";
-import { FONOSTER_SERVER_CONFIG } from "../stores/fonoster.config";
 import { cache } from "react";
 import { Logger } from "~/core/shared/logger";
+import { RUNTIME_CONFIG } from "~/core/config/fonoster.runtime-config";
+
+/**
+ * Creates server configuration object from runtime config.
+ * Used for server-side Client instances.
+ */
+const createServerConfig = () => {
+  return Object.freeze({
+    endpoint: RUNTIME_CONFIG.APISERVER_CONNECTION.grpc_address,
+    accessKeyId: "",
+    allowInsecure: RUNTIME_CONFIG.APISERVER_CONNECTION.allowInsecure,
+    accessToken: ""
+  });
+};
 
 /**
  * Creates and returns a memoized (cached) instance of the Fonoster Client
- * for server-side use, using a predefined server configuration.
+ * for server-side use, using runtime configuration.
  *
  * The `cache()` utility ensures that the same instance is reused across
  * multiple calls within the same request lifecycle (as used in server-rendered apps).
@@ -46,10 +59,12 @@ import { Logger } from "~/core/shared/logger";
  * @returns {Client} A configured instance of the Fonoster SDK Client for Node.js.
  */
 export const getClient = cache(() => {
-  Logger.debug("[fonoster.server] Creating Fonoster Client instance");
-
-  const fonosterClient = new SDK.Client(FONOSTER_SERVER_CONFIG);
-  return fonosterClient;
+  const serverConfig = createServerConfig();
+  Logger.debug(
+    "[fonoster.server] Creating Fonoster Client instance with server config",
+    serverConfig
+  );
+  return new SDK.Client(serverConfig);
 });
 
 /**

--- a/mods/dashboard/src/core/shared/logger.ts
+++ b/mods/dashboard/src/core/shared/logger.ts
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+import { RUNTIME_CONFIG } from "~/core/config/fonoster.runtime-config";
+
 /**
  * Logger utility class.
  *
@@ -32,7 +34,7 @@ export class Logger {
    * Determines if the application is running in development mode.
    * Controls whether debug logs are displayed.
    */
-  private static readonly __IS_DEVELOPMENT__ = import.meta.env.DEV;
+  private static readonly __IS_DEVELOPMENT__ = RUNTIME_CONFIG.DEVELOPMENT;
 
   /**
    * Logs a debug message to the console.

--- a/mods/dashboard/src/root.tsx
+++ b/mods/dashboard/src/root.tsx
@@ -32,6 +32,7 @@ import { metadata } from "./core/helpers/metadata";
 import { ErrorLayout } from "./core/components/general/error-boundary/error-boundary";
 import { Splash } from "./core/components/general/splash/splash";
 import { FonosterProvider } from "./core/sdk/stores/fonoster.store";
+import { RUNTIME_CONFIG } from "./core/config/fonoster.runtime-config";
 
 /**
  * Links
@@ -122,6 +123,11 @@ export function Layout({ children }: { children: React.ReactNode }) {
         />
         <Meta />
         <Links />
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `window.__FONOSTER_RUNTIME_CONFIG__ = ${JSON.stringify(RUNTIME_CONFIG)};`
+          }}
+        />
       </head>
       <body>
         <Providers>{children}</Providers>


### PR DESCRIPTION
## Description
Currently, the dashboard module has to be rebuilt every time there is a configuration change. This is not ideal because rebuilding the dashboard can take some time. 

This PR introduces 2 new concepts:
1. Runtime Config - to supply values that could be provided at startup time by setting appropriate env variables
2. BuildTime Config - to supply values that should be embedded during build time 

<!--
  Please include a summary of the changes and the related issue. 
  Please also include relevant motivation and context. 
  List any dependencies that are required for this change.
-->

## Type of change

<!-- 
  Choose all that apply and delete options that are not relevant.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested locally with Docker/Compose on WSL 

<!-- 
  Please describe the tests that you ran to verify your changes. 
  Provide instructions so we can reproduce. 
  Please also list any relevant details for your test configuration 
-->

## Checklist:

<!-- Please delete options that are not relevant. -->

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules