### PR TITLE
fix(ctl): make app update ref optional and fix --from-file precedence

### DIFF
--- a/mods/ctl/src/commands/applications/update.ts
+++ b/mods/ctl/src/commands/applications/update.ts
@@ -30,8 +30,8 @@ export default class Update extends AuthenticatedCommand<typeof Update> {
   static override readonly examples = ["<%= config.bin %> <%= command.id %>"];
   static override readonly args = {
     ref: Args.string({
-      description: "the Application to update",
-      required: true
+      description:
+        "the Application to update (optional when `ref` is set in --from-file)"
     })
   };
 
@@ -52,7 +52,8 @@ export default class Update extends AuthenticatedCommand<typeof Update> {
         await createOrUpdateApplication(
           client,
           flags["from-file"] as string,
-          ref
+          ref,
+          true
         );
         this.log("Done!");
         return;
@@ -62,9 +63,15 @@ export default class Update extends AuthenticatedCommand<typeof Update> {
       }
     }
 
+    if (!ref) {
+      this.error(
+        "An Application ref is required. Pass it as the positional argument or use --from-file with a `ref` field."
+      );
+    }
+
     const client = await this.createSdkClient();
     const applications = new SDK.Applications(client);
-    const applicationFromDB = await applications.getApplication(args.ref);
+    const applicationFromDB = await applications.getApplication(ref);
 
     if (!applicationFromDB) {
       this.error("Application not found.");

--- a/mods/ctl/src/utils/createOrUpdateApplication.ts
+++ b/mods/ctl/src/utils/createOrUpdateApplication.ts
@@ -29,16 +29,18 @@ import { AppConfig } from "./types";
 export async function createOrUpdateApplication(
   client: SDK.Client,
   filePath: string,
-  appRef?: string
+  appRef?: string,
+  isUpdate = false
 ) {
   const fileContent = readFileSync(filePath, "utf8");
   const fileExt = path.extname(filePath).toLowerCase();
-  let config: CreateApplicationRequest & AppConfig;
+  type Config = CreateApplicationRequest & AppConfig & { ref?: string };
+  let config: Config;
 
   if (fileExt === ".yaml" || fileExt === ".yml") {
-    config = load(fileContent) as CreateApplicationRequest & AppConfig;
+    config = load(fileContent) as Config;
   } else if (fileExt === ".json") {
-    config = JSON.parse(fileContent) as CreateApplicationRequest & AppConfig;
+    config = JSON.parse(fileContent) as Config;
   } else {
     throw new Error("Unsupported file format. Please use YAML or JSON files.");
   }
@@ -48,13 +50,24 @@ export async function createOrUpdateApplication(
   delete config.testCases;
   delete config.intelligence?.config?.languageModel?.apiKey;
 
-  if (appRef) {
+  if (isUpdate) {
+    // The positional appRef takes precedence over any `ref` in the file; fall
+    // back to the file's `ref` when the positional is omitted.
+    const ref = appRef ?? config.ref;
+
+    if (!ref) {
+      throw new Error(
+        "An Application ref is required to update. Provide it as the positional argument or include `ref` in the file."
+      );
+    }
+
+    delete config.ref;
     const updateConfig: UpdateApplicationRequest = {
-      ref: appRef,
-      ...config
+      ...config,
+      ref
     };
     return applications.updateApplication(updateConfig);
-  } else {
-    return applications.createApplication(config);
   }
+
+  return applications.createApplication(config);
 }

--- a/mods/ctl/test/createOrUpdateApplication.test.ts
+++ b/mods/ctl/test/createOrUpdateApplication.test.ts
@@ -1,0 +1,131 @@
+/*
+ * Copyright (C) 2025 by Fonoster Inc (https://fonoster.com)
+ * http://github.com/fonoster/fonoster
+ *
+ * This file is part of Fonoster
+ *
+ * Licensed under the MIT License (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    https://opensource.org/licenses/MIT
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import * as SDK from "@fonoster/sdk";
+import * as chai from "chai";
+import { expect } from "chai";
+import chaiAsPromised from "chai-as-promised";
+import { createSandbox } from "sinon";
+import sinonChai from "sinon-chai";
+import { createOrUpdateApplication } from "../src/utils/createOrUpdateApplication";
+
+chai.use(chaiAsPromised);
+chai.use(sinonChai);
+const sandbox = createSandbox();
+
+describe("@ctl[utils/createOrUpdateApplication]", function () {
+  let tmpDir: string;
+  let createStub: sinon.SinonStub;
+  let updateStub: sinon.SinonStub;
+  const client = {} as unknown as SDK.Client;
+
+  // A minimal but valid-shaped application config.
+  const baseConfig = {
+    name: "My App",
+    type: "EXTERNAL",
+    endpoint: "example.com"
+  };
+
+  function writeConfig(ext: string, content: unknown): string {
+    const filePath = join(tmpDir, `app.${ext}`);
+    const data =
+      typeof content === "string" ? content : JSON.stringify(content);
+    writeFileSync(filePath, data, "utf8");
+    return filePath;
+  }
+
+  beforeEach(function () {
+    tmpDir = mkdtempSync(join(tmpdir(), "ctl-app-"));
+    createStub = sandbox
+      .stub(SDK.Applications.prototype, "createApplication")
+      .resolves({ ref: "created-ref" });
+    updateStub = sandbox
+      .stub(SDK.Applications.prototype, "updateApplication")
+      .resolves({ ref: "updated-ref" });
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("creates an application when isUpdate is false", async function () {
+    const filePath = writeConfig("json", baseConfig);
+
+    await createOrUpdateApplication(client, filePath);
+
+    expect(createStub).to.have.been.calledOnce;
+    expect(updateStub).to.not.have.been.called;
+    expect(createStub.firstCall.args[0]).to.include(baseConfig);
+  });
+
+  it("updates using the positional ref when provided", async function () {
+    const filePath = writeConfig("json", baseConfig);
+
+    await createOrUpdateApplication(client, filePath, "positional-ref", true);
+
+    expect(updateStub).to.have.been.calledOnce;
+    expect(createStub).to.not.have.been.called;
+    expect(updateStub.firstCall.args[0]).to.have.property(
+      "ref",
+      "positional-ref"
+    );
+  });
+
+  it("lets the positional ref override a ref in the file", async function () {
+    const filePath = writeConfig("json", { ...baseConfig, ref: "file-ref" });
+
+    await createOrUpdateApplication(client, filePath, "positional-ref", true);
+
+    expect(updateStub.firstCall.args[0]).to.have.property(
+      "ref",
+      "positional-ref"
+    );
+  });
+
+  it("falls back to the file ref when the positional is omitted", async function () {
+    const filePath = writeConfig("yaml", `name: My App\nref: file-ref\n`);
+
+    await createOrUpdateApplication(client, filePath, undefined, true);
+
+    expect(updateStub).to.have.been.calledOnce;
+    expect(updateStub.firstCall.args[0]).to.have.property("ref", "file-ref");
+  });
+
+  it("throws a clear error when no ref is available for an update", async function () {
+    const filePath = writeConfig("json", baseConfig);
+
+    await expect(
+      createOrUpdateApplication(client, filePath, undefined, true)
+    ).to.be.rejectedWith(/Application ref is required/);
+
+    expect(updateStub).to.not.have.been.called;
+    expect(createStub).to.not.have.been.called;
+  });
+
+  it("rejects unsupported file formats", async function () {
+    const filePath = writeConfig("txt", "name: My App");
+
+    await expect(
+      createOrUpdateApplication(client, filePath, "ref", true)
+    ).to.be.rejectedWith(/Unsupported file format/);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #858 — the `apps:update` (CTL) positional `appRef` was `required` and, when the `--from-file` payload also contained a `ref`, the file's value silently overrode the positional argument (the inverse of the expected precedence).

## Changes

- **`mods/ctl/src/commands/applications/update.ts`**
  - Make the positional `ref` **optional**.
  - Guard the interactive (non-`--from-file`) path with a clear error when no ref is given, and use the resolved `ref` consistently.
  - Pass an explicit `isUpdate` flag to the helper.
- **`mods/ctl/src/utils/createOrUpdateApplication.ts`**
  - Resolve precedence explicitly: `const ref = appRef ?? config.ref` (positional wins).
  - Place the resolved `ref` **last** in the update payload (`{ ...config, ref }` after `delete config.ref`) so it isn't clobbered by the spread.
  - Use the explicit `isUpdate` flag so an exported file containing `ref` can't accidentally route the **create** command into an update.
  - Throw a clear error when neither source provides a `ref`.
- **`mods/ctl/test/createOrUpdateApplication.test.ts`** — new unit tests (stubbed SDK, temp fixture files, no infra) covering create, positional override, file fallback, missing-ref error, and unsupported format.

## Acceptance criteria

| Criterion | Status |
|---|---|
| Positional `appRef` optional | ✅ |
| Positional overrides file `ref` | ✅ |
| Falls back to file `ref` when omitted | ✅ |
| Clear error when neither provides `ref` | ✅ |

## Testing

- `mocha mods/ctl/test/createOrUpdateApplication.test.ts` → 6 passing
- `tsc --noEmit -p mods/ctl/tsconfig.json` → clean

Closes #858

🤖 Generated with [Claude Code](https://claude.com/claude-code)