### PR TITLE
fix(identity-client): expose Workspace.owner in the TS type

### DIFF
--- a/mods/identity-client/src/index.ts
+++ b/mods/identity-client/src/index.ts
@@ -85,6 +85,12 @@ export interface Workspace {
   accessKeyId: string;
   createdAt?: number;
   updatedAt?: number;
+  /** The workspace owner's own profile (never a WorkspaceMember row). */
+  owner?: {
+    ref: string;
+    name: string;
+    email: string;
+  };
 }
 
 export interface WorkspaceMember {


### PR DESCRIPTION
## Summary
- `Workspace.owner` (an `Owner{ref,name,email}` submessage) has been on the proto/wire since `listWorkspaces` started `include: { owner: {...} }`-ing it in Prisma - it's in every response today.
- `identity-client`'s own hand-written `Workspace` interface never declared it, so callers had no type-safe way to read the real workspace owner's name/email - a downstream consumer (qcobro) needs this to show the owner's real name instead of guessing from the current caller's identity.
- Purely additive: one new optional field on an existing interface.

## Test plan
- [x] `tsc -b` clean on `identity-client` and `apiserver` (both consumers of `Workspace`)
- [x] `eslint` clean
- No runtime change - type-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019USAno3Rwc1WcMD1vFboMW