### PR TITLE
fix(voice): settle a verb when the session ends instead of hanging forever

### DIFF
--- a/mods/voice/src/createSession.ts
+++ b/mods/voice/src/createSession.ts
@@ -33,7 +33,21 @@ function createSession(handler: VoiceHandler) {
         if (request) {
           mediaSessionRef = request.mediaSessionRef;
           const response = new VoiceResponse(request, voice);
-          await handler(request, response);
+
+          // EventEmitter ignores the promise this callback returns, so an error
+          // escaping the handler becomes an unhandled rejection and, under Node's
+          // default policy, takes the whole voice server down with it. Verbs now
+          // reject when the session ends mid-call, which makes reaching here an
+          // ordinary occurrence rather than a defect in the application.
+          try {
+            await handler(request, response);
+          } catch (e) {
+            logger.warn("voice handler did not complete", {
+              mediaSessionRef,
+              error: e instanceof Error ? e.message : e
+            });
+          }
+
           resolve();
         }
       });

--- a/mods/voice/src/verbs/Verb.ts
+++ b/mods/voice/src/verbs/Verb.ts
@@ -48,6 +48,54 @@ abstract class Verb<T extends VerbRequest = VerbRequest> {
     });
 
     return new Promise((resolve, reject) => {
+      // Every exit path must remove all three listeners. A verb shares the session
+      // stream with every other verb in the call, so anything left attached
+      // accumulates for the lifetime of the session.
+      const cleanup = () => {
+        voice.removeListener(StreamEvent.DATA, dataListener);
+        voice.removeListener(StreamEvent.END, endListener);
+        voice.removeListener(StreamEvent.ERROR, errorListener);
+      };
+
+      const dataListener = (result: VoiceIn) => {
+        const expectedContent = getExpectedContent(this.constructor.name);
+
+        if (expectedContent !== result.content) {
+          return;
+        }
+
+        logger.verbose(`received ${this.constructor.name} response`, {
+          mediaSessionRef
+        });
+        cleanup();
+        resolve(result);
+      };
+
+      // Without these the promise has exactly one exit: a matching response. When the
+      // session dies first — the caller hangs up mid-verb, or the transport fails —
+      // it is left pending forever, neither resolved nor rejected. The application
+      // then awaits a verb that can never complete and the call is stranded rather
+      // than failed.
+      const endListener = () => {
+        cleanup();
+        reject(
+          new Error(
+            `voice session ended before the ${this.constructor.name} verb completed`
+          )
+        );
+      };
+
+      const errorListener = (error: unknown) => {
+        cleanup();
+        reject(
+          error instanceof Error
+            ? error
+            : new Error(
+                `voice session failed during the ${this.constructor.name} verb: ${error}`
+              )
+        );
+      };
+
       try {
         const fullRequest = {
           ...params,
@@ -56,26 +104,17 @@ abstract class Verb<T extends VerbRequest = VerbRequest> {
 
         validateRequest<T>(this.getValidationSchema(), fullRequest);
 
+        // Listen before writing: a response cannot be delivered to a listener that
+        // does not exist yet.
+        voice.on(StreamEvent.DATA, dataListener);
+        voice.on(StreamEvent.END, endListener);
+        voice.on(StreamEvent.ERROR, errorListener);
+
         voice.write({
           [`${toCamelCase(this.constructor.name)}Request`]: fullRequest
         });
-
-        const dataListener = (result: VoiceIn) => {
-          const expectedContent = getExpectedContent(this.constructor.name);
-
-          if (expectedContent !== result.content) {
-            return;
-          }
-
-          logger.verbose(`received ${this.constructor.name} response`, {
-            mediaSessionRef
-          });
-          resolve(result);
-          voice.removeListener(StreamEvent.DATA, dataListener);
-        };
-
-        voice.on(StreamEvent.DATA, dataListener);
       } catch (e) {
+        cleanup();
         reject(e);
       }
     });

--- a/mods/voice/test/answer.test.ts
+++ b/mods/voice/test/answer.test.ts
@@ -44,8 +44,8 @@ describe("@voice/verbs/answer", function () {
     await answer.run();
 
     // Assert
-    expect(voice.removeListener).to.have.been.calledOnce;
-    expect(voice.on).to.have.been.calledOnce;
+    expect(voice.removeListener).to.have.been.calledThrice;
+    expect(voice.on).to.have.been.calledThrice;
     expect(voice.write).to.have.been.calledOnce;
     expect(voice.write).to.have.been.calledWith({
       answerRequest: { mediaSessionRef }

--- a/mods/voice/test/createSession.test.ts
+++ b/mods/voice/test/createSession.test.ts
@@ -59,7 +59,12 @@ describe("@voice/createSession", function () {
     const onStub = sandbox
       .stub()
       .callsFake((event: StreamEvent, cb: (params) => void) => {
-        cb(callbackResponses[cnt++]);
+        // Only a DATA registration receives a response. A verb also listens for END
+        // and ERROR so it cannot hang when the session dies mid-call; handing those
+        // a verb response would settle the promise down the wrong path.
+        if (event === StreamEvent.DATA) {
+          cb(callbackResponses[cnt++]);
+        }
       });
 
     const voice = {
@@ -85,7 +90,9 @@ describe("@voice/createSession", function () {
     expect(voice.once).to.have.been.calledWith(StreamEvent.DATA, match.func);
     expect(voice.once).to.have.been.calledWith(StreamEvent.END, match.func);
     expect(voice.once).to.have.been.calledTwice;
-    expect(voice.on).to.have.been.calledThrice;
+    // Three verbs, each listening for DATA, END and ERROR so that none of them can
+    // hang if the session terminates before its response arrives.
+    expect(voice.on).to.have.callCount(9);
     expect(voice.write).to.have.been.calledThrice;
     expect(voice.write).to.have.been.calledWith({
       answerRequest: { mediaSessionRef }

--- a/mods/voice/test/dial.test.ts
+++ b/mods/voice/test/dial.test.ts
@@ -51,8 +51,8 @@ describe("@voice/verbs/dial", function () {
     await dial.run(dialRequest);
 
     // Assert
-    expect(voice.removeListener).to.have.been.calledOnce;
-    expect(voice.on).to.have.been.calledOnce;
+    expect(voice.removeListener).to.have.been.calledThrice;
+    expect(voice.on).to.have.been.calledThrice;
     expect(voice.on).to.have.been.calledWith("data", match.func);
     expect(voice.write).to.have.been.calledOnce;
     expect(voice.write).to.have.been.calledWith({

--- a/mods/voice/test/gather.test.ts
+++ b/mods/voice/test/gather.test.ts
@@ -52,8 +52,8 @@ describe("@voice/verbs/gather", function () {
     await gather.run(gatherRequest);
 
     // Assert
-    expect(voice.removeListener).to.have.been.calledOnce;
-    expect(voice.on).to.have.been.calledOnce;
+    expect(voice.removeListener).to.have.been.calledThrice;
+    expect(voice.on).to.have.been.calledThrice;
     expect(voice.on).to.have.been.calledWith("data", match.func);
     expect(voice.write).to.have.been.calledOnce;
     expect(voice.write).to.have.been.calledWith({

--- a/mods/voice/test/helpers.ts
+++ b/mods/voice/test/helpers.ts
@@ -16,6 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { StreamEvent } from "@fonoster/common";
 import { CallDirection } from "@fonoster/types";
 import { SinonSandbox } from "sinon";
 import { VoiceRequest } from "../src";
@@ -38,8 +39,14 @@ const voiceRequest: VoiceRequest = {
 };
 
 function getVoiceObject(sandbox: SinonSandbox, resultContent: string) {
-  const onStub = sandbox.stub().callsFake((_, cb) => {
-    cb({ content: resultContent });
+  // Only a DATA registration yields a response. Firing the callback for every event
+  // would mean an END or ERROR listener also receives one, which is both unlike the
+  // real stream and the reason a verb that never settled on stream termination went
+  // unnoticed by this suite.
+  const onStub = sandbox.stub().callsFake((event, cb) => {
+    if (event === StreamEvent.DATA) {
+      cb({ content: resultContent });
+    }
   });
 
   return {

--- a/mods/voice/test/mute.test.ts
+++ b/mods/voice/test/mute.test.ts
@@ -50,8 +50,8 @@ describe("@voice/verbs/mute", function () {
     await mute.run(muteRequest);
 
     // Assert
-    expect(voice.removeListener).to.have.been.calledOnce;
-    expect(voice.on).to.have.been.calledOnce;
+    expect(voice.removeListener).to.have.been.calledThrice;
+    expect(voice.on).to.have.been.calledThrice;
     expect(voice.on).to.have.been.calledWith(StreamEvent.DATA, match.func);
     expect(voice.write).to.have.been.calledOnce;
     expect(voice.write).to.have.been.calledWith({

--- a/mods/voice/test/play.test.ts
+++ b/mods/voice/test/play.test.ts
@@ -50,8 +50,8 @@ describe("@voice/verbs/play", function () {
     await play.run(playRequest);
 
     // Assert
-    expect(voice.removeListener).to.have.been.calledOnce;
-    expect(voice.on).to.have.been.calledOnce;
+    expect(voice.removeListener).to.have.been.calledThrice;
+    expect(voice.on).to.have.been.calledThrice;
     expect(voice.on).to.have.been.calledWith("data", match.func);
     expect(voice.write).to.have.been.calledOnce;
     expect(voice.write).to.have.been.calledWith({

--- a/mods/voice/test/playDtmf.test.ts
+++ b/mods/voice/test/playDtmf.test.ts
@@ -50,8 +50,8 @@ describe("@voice/verbs/playDtmf", function () {
     await playDtmf.run(playDtmfRequest);
 
     // Assert
-    expect(voice.removeListener).to.have.been.calledOnce;
-    expect(voice.on).to.have.been.calledOnce;
+    expect(voice.removeListener).to.have.been.calledThrice;
+    expect(voice.on).to.have.been.calledThrice;
     expect(voice.on).to.have.been.calledWith("data", match.func);
     expect(voice.write).to.have.been.calledOnce;
     expect(voice.write).to.have.been.calledWith({

--- a/mods/voice/test/playbackControl.test.ts
+++ b/mods/voice/test/playbackControl.test.ts
@@ -54,8 +54,8 @@ describe("@voice/verbs/playbackControl", function () {
     await playbackControl.run(playbackControlRequest);
 
     // Assert
-    expect(voice.removeListener).to.have.been.calledOnce;
-    expect(voice.on).to.have.been.calledOnce;
+    expect(voice.removeListener).to.have.been.calledThrice;
+    expect(voice.on).to.have.been.calledThrice;
     expect(voice.on).to.have.been.calledWith("data", match.func);
     expect(voice.write).to.have.been.calledOnce;
     expect(voice.write).to.have.been.calledWith({

--- a/mods/voice/test/record.test.ts
+++ b/mods/voice/test/record.test.ts
@@ -52,8 +52,8 @@ describe("@voice/verbs/record", function () {
     await record.run(recordRequest);
 
     // Assert
-    expect(voice.removeListener).to.have.been.calledOnce;
-    expect(voice.on).to.have.been.calledOnce;
+    expect(voice.removeListener).to.have.been.calledThrice;
+    expect(voice.on).to.have.been.calledThrice;
     expect(voice.on).to.have.been.calledWith("data", match.func);
     expect(voice.write).to.have.been.calledOnce;
     expect(voice.write).to.have.been.calledWith({

--- a/mods/voice/test/say.test.ts
+++ b/mods/voice/test/say.test.ts
@@ -57,8 +57,8 @@ describe("@voice/verbs/play", function () {
     await say.run(sayRequest);
 
     // Assert
-    expect(voice.removeListener).to.have.been.calledOnce;
-    expect(voice.on).to.have.been.calledOnce;
+    expect(voice.removeListener).to.have.been.calledThrice;
+    expect(voice.on).to.have.been.calledThrice;
     expect(voice.on).to.have.been.calledWith("data", match.func);
     expect(voice.write).to.have.been.calledOnce;
     expect(voice.write).to.have.been.calledWith({

--- a/mods/voice/test/sgather.test.ts
+++ b/mods/voice/test/sgather.test.ts
@@ -50,8 +50,8 @@ describe("@voice/verbs/SGather", function () {
     await startStreamGather.run(startStreamGatherRequest);
 
     // Assert
-    expect(voice.removeListener).to.have.been.calledOnce;
-    expect(voice.on).to.have.been.calledOnce;
+    expect(voice.removeListener).to.have.been.calledThrice;
+    expect(voice.on).to.have.been.calledThrice;
     expect(voice.on).to.have.been.calledWith("data", match.func);
     expect(voice.write).to.have.been.calledOnce;
     expect(voice.write).to.have.been.calledWith({

--- a/mods/voice/test/stream.test.ts
+++ b/mods/voice/test/stream.test.ts
@@ -56,8 +56,8 @@ describe("@voice/verbs/stream", function () {
     await startStream.run(startStreamRequest);
 
     // Assert
-    expect(voice.removeListener).to.have.been.calledOnce;
-    expect(voice.on).to.have.been.calledOnce;
+    expect(voice.removeListener).to.have.been.calledThrice;
+    expect(voice.on).to.have.been.calledThrice;
     expect(voice.on).to.have.been.calledWith("data", match.func);
     expect(voice.write).to.have.been.calledOnce;
     expect(voice.write).to.have.been.calledWith({

--- a/mods/voice/test/unmute.test.ts
+++ b/mods/voice/test/unmute.test.ts
@@ -46,8 +46,8 @@ describe("@voice/verbs/unmute", function () {
     await unmute.run({ mediaSessionRef, direction: MuteDirection.IN });
 
     // Assert
-    expect(voice.removeListener).to.have.been.calledOnce;
-    expect(voice.on).to.have.been.calledOnce;
+    expect(voice.removeListener).to.have.been.calledThrice;
+    expect(voice.on).to.have.been.calledThrice;
     expect(voice.on).to.have.been.calledWith("data", match.func);
     expect(voice.write).to.have.been.calledOnce;
     expect(voice.write).to.have.been.calledWith({

--- a/mods/voice/test/verbHang.test.ts
+++ b/mods/voice/test/verbHang.test.ts
@@ -1,0 +1,160 @@
+/*
+ * Copyright (C) 2025 by Fonoster Inc (https://fonoster.com)
+ * http://github.com/fonoster/fonoster
+ *
+ * This file is part of Fonoster
+ *
+ * Licensed under the MIT License (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    https://opensource.org/licenses/MIT
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { EventEmitter } from "events";
+import { StreamEvent, VoiceSessionStreamServer } from "@fonoster/common";
+import * as chai from "chai";
+import { expect } from "chai";
+import chaiAsPromised from "chai-as-promised";
+import { createSandbox } from "sinon";
+import sinonChai from "sinon-chai";
+import { voiceRequest } from "./helpers";
+
+chai.use(chaiAsPromised);
+chai.use(sinonChai);
+const sandbox = createSandbox();
+
+const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Reports how a promise settled, or "pending" if it never did. A verb that hangs
+ * forever would otherwise surface as an opaque mocha timeout; this makes the failure
+ * message say exactly what went wrong.
+ */
+async function settleWithin(promise: Promise<unknown>, ms: number) {
+  return Promise.race([
+    promise.then(
+      () => "resolved" as const,
+      () => "rejected" as const
+    ),
+    delay(ms).then(() => "pending" as const)
+  ]);
+}
+
+/**
+ * An EventEmitter-backed stand-in for the gRPC session stream, so the test can end or
+ * fail the stream the way the transport does. `fire` refuses to emit an ERROR nobody
+ * is listening for: a bare EventEmitter throws in that case, which would mask the
+ * behaviour under test behind an unrelated exception.
+ */
+function createStreamFake() {
+  const emitter = new EventEmitter();
+  const stream = {
+    on: (event: string, cb: (...args: unknown[]) => void) => emitter.on(event, cb),
+    once: (event: string, cb: (...args: unknown[]) => void) =>
+      emitter.once(event, cb),
+    removeListener: (event: string, cb: (...args: unknown[]) => void) =>
+      emitter.removeListener(event, cb),
+    write: sandbox.stub(),
+    end: sandbox.stub()
+  };
+  return {
+    stream: stream as unknown as VoiceSessionStreamServer,
+    fire: (event: StreamEvent, payload?: unknown) => {
+      if (emitter.listenerCount(event) === 0) return false;
+      return emitter.emit(event, payload);
+    },
+    listenerCount: (event: StreamEvent) => emitter.listenerCount(event)
+  };
+}
+
+describe("@voice/verbs/stream termination", function () {
+  afterEach(function () {
+    return sandbox.restore();
+  });
+
+  it("resolves when the matching response arrives (CONTROL)", async function () {
+    const voice = createStreamFake();
+    const { Answer } = await import("../src/verbs");
+    const answer = new Answer(voiceRequest, voice.stream);
+
+    const running = answer.run();
+    voice.fire(StreamEvent.DATA, { content: "answerResponse" });
+
+    expect(await settleWithin(running, 300)).to.equal("resolved");
+  });
+
+  it("REGRESSION: rejects when the session ends before the response arrives", async function () {
+    // The caller hangs up mid-verb. Verb.run() resolves only from its DATA listener
+    // and rejects only from the synchronous try/catch, so the promise is abandoned:
+    // never resolved, never rejected. The application awaits it forever, which is why
+    // a dropped call leaves a gestión stuck instead of failing.
+    const voice = createStreamFake();
+    const { Answer } = await import("../src/verbs");
+    const answer = new Answer(voiceRequest, voice.stream);
+
+    const running = answer.run();
+    voice.fire(StreamEvent.END);
+
+    expect(await settleWithin(running, 300)).to.equal("rejected");
+  });
+
+  it("REGRESSION: rejects when the session errors before the response arrives", async function () {
+    const voice = createStreamFake();
+    const { Answer } = await import("../src/verbs");
+    const answer = new Answer(voiceRequest, voice.stream);
+
+    const running = answer.run();
+    voice.fire(StreamEvent.ERROR, new Error("stream failed"));
+
+    expect(await settleWithin(running, 300)).to.equal("rejected");
+  });
+
+  it("REGRESSION: removes its listeners when the session ends", async function () {
+    // The resolve path removes the DATA listener; no other path does. Every dropped
+    // call therefore leaks a listener and the closure it holds.
+    const voice = createStreamFake();
+    const { Answer } = await import("../src/verbs");
+    const answer = new Answer(voiceRequest, voice.stream);
+
+    const running = answer.run();
+    expect(voice.listenerCount(StreamEvent.DATA)).to.equal(1);
+
+    voice.fire(StreamEvent.END);
+    await settleWithin(running, 300);
+
+    expect(voice.listenerCount(StreamEvent.DATA)).to.equal(0);
+  });
+
+  it("REGRESSION: a rejecting handler must not escape as an unhandled rejection", async function () {
+    // createSession awaits the handler inside an async `once` callback. EventEmitter
+    // ignores the returned promise, so a handler that throws — which is exactly what a
+    // verb rejecting on stream end now causes — becomes an unhandled rejection and
+    // takes the whole process down under Node's default policy.
+    const voice = createStreamFake();
+    const { createSession } = await import("../src/createSession");
+
+    const escaped: unknown[] = [];
+    const onUnhandled = (reason: unknown) => escaped.push(reason);
+    process.on("unhandledRejection", onUnhandled);
+
+    try {
+      const session = createSession(async () => {
+        throw new Error("verb failed because the session ended");
+      })(voice.stream);
+
+      voice.fire(StreamEvent.DATA, { request: voiceRequest });
+      const outcome = await settleWithin(session, 300);
+
+      expect(escaped, "handler rejection escaped the session").to.be.empty;
+      expect(outcome, "session promise never settled").to.not.equal("pending");
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+    }
+  });
+});


### PR DESCRIPTION
## The bug

`Verb.run()` returned a promise with exactly one exit: a `DATA` event carrying the matching response. `reject()` was reachable only from the synchronous try/catch around `validateRequest`/`write`. Nothing listened for `END` or `ERROR`.

When the session died first — the caller hangs up mid-verb, or the transport fails — the promise was **abandoned: never resolved, never rejected**. The application awaited a verb that could no longer complete, its handler never returned, and the call was stranded rather than failed.

The sharpest consequence is that this is unreachable from application code. Recovery logic is a `catch` block, and nothing was ever thrown — so an application that correctly handles verb failures still hangs.

Two smaller defects travelled with it:

- **Listener leak.** Only the resolve path removed the `DATA` listener. Verbs share one stream for the whole session, so every terminated call leaked a listener and the closure it held.
- **Response before listener.** `write()` happened before `voice.on(DATA, …)`, the same ordering mistake fixed in #879.

Seen in production: an outbound call torn down ~600ms after answer left the verb pending and the record stuck at its dispatch state for ten minutes, until a sweep closed it out as a provider error — indistinguishable from a call that never connected.

## The fix

- `Verb.run()` listens for `END` and `ERROR` and rejects on both; every exit path removes all three listeners; listeners are attached **before** the write.
- `createSession` catches handler errors. It awaits the handler inside an async `once` callback whose promise EventEmitter discards, so an error escaping the handler became an **unhandled rejection and took the whole voice server down** under Node's default policy. Verbs rejecting on session end makes that an ordinary occurrence rather than an application defect, so it has to be contained. This half is not optional — without it the first half turns hangs into crashes.

## Why 15 files

The verb test doubles fired their callback for **every** listener registration, not just `DATA`. That is unlike the real stream, and it is why a verb that never settled on stream termination went unnoticed by this suite: an `END` listener would have been handed a verb response.

The doubles are now event-aware, and the affected assertions updated to the new contract — three registrations and three removals per verb. The source change is 2 files; the other 13 are that contract update.

## Verification

`mods/voice/test/verbHang.test.ts` drives real verbs against an `EventEmitter`-backed stream so the session can be ended or failed the way the transport does.

| test | before | after |
|---|---|---|
| resolves on matching response (CONTROL) | ✅ | ✅ |
| rejects when the session ends | ❌ `pending` | ✅ |
| rejects when the session errors | ❌ `pending` | ✅ |
| removes its listeners when the session ends | ❌ `1` left | ✅ |
| handler rejection must not escape unhandled | ❌ 2 escaped | ✅ |

Failures report `pending` rather than a mocha timeout, so a hang says what it is.

## Checks

- `verbHang.test.ts`: 5 passing (verified red-then-green — 1 passing / 4 failing with the source change reverted)
- Full repo suite: **217 passing**, 3 pending
- `tsc -b` clean, ESLint clean

Follow-up, not in this PR: with verbs now failing fast, `@fonoster/apiserver` may want a timeout of its own so a provider that neither responds nor closes the stream still terminates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)